### PR TITLE
ignore vscode options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# vscode
+/.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "git.ignoreLimitWarning": true
-}


### PR DESCRIPTION
Porque por ejemplo agregué un uso personalizado de fuentes para mi ide:
    "terminal.integrated.fontFamily": "MesloLGM Nerd Font",
    "terminal.integrated.fontSize": 12
y no es necesario que lo tengan todos, son settings personales...