### PR TITLE
userContext & SyncModalContext

### DIFF
--- a/src/app/club/select/page.tsx
+++ b/src/app/club/select/page.tsx
@@ -6,7 +6,7 @@ import { Header } from "@/components/header/header";
 export default function ClubSelect() {
     return (
     <>
-        <Header defaultPopSyncModal={false}/>
+        <Header/>
         <div className="flex flex-col items-center">
             <h1 className="text-center m-10">CLUBES</h1>
             <ClubTableServer />

--- a/src/app/global.d.ts
+++ b/src/app/global.d.ts
@@ -5,4 +5,5 @@ declare global {
     type Member = Tables<'members'>
     type Club = Tables<'clubs'>
     type User = Tables<'auth.users'>
+    type Guest = Tables<'guests'>
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { SyncModalProvider } from "@/contexts/SyncModalContext";
 import "./globals.css";
+import { UserProvider } from "@/contexts/UserContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -22,9 +23,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
       <html lang="es">
           <body>
-              <SyncModalProvider defaultPopSyncModal={false}>
-                  {children}
-              </SyncModalProvider>
+            <UserProvider>
+                <SyncModalProvider>
+                    {children}
+                </SyncModalProvider>
+              </UserProvider>
           </body>
       </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ export default async function Home() {
 
     return (
         <>
-            <Header defaultPopSyncModal={true} onCloseSyncModal={"/club/select"} />
+            <Header/>
             <div className="flex flex-col items-center min-h-screen p-4 bg-cover bg-center">
 
 

--- a/src/components/auth-button.tsx
+++ b/src/components/auth-button.tsx
@@ -12,7 +12,6 @@ export function AuthButton() {
   const supabase = createClient();
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
-  const { setPopSyncModal } = useSyncModal(); // Usamos setPopSyncModal del contexto el cual permite activar o desactivar el modal de sincronización
 
   useEffect(() => {
     const getSession = async () => {
@@ -20,15 +19,10 @@ export function AuthButton() {
         data: { session },
       } = await supabase.auth.getSession();
       setUser(session?.user || null);
-
-      // Si hay un usuario, activamos popSyncModal
-      if (session?.user) {
-        setPopSyncModal(true);
-      }
     };
 
     getSession();
-  }, [supabase, setPopSyncModal]);
+  }, [supabase]);
 
   const handleSignIn = async () => {
     await supabase.auth.signInWithOAuth({

--- a/src/components/buttons/auth-button.tsx
+++ b/src/components/buttons/auth-button.tsx
@@ -1,47 +1,19 @@
-"use client";
+'use client';
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { createClient } from "@/utils/supabase/client";
-import { User } from "@supabase/supabase-js"; // Asegúrate de importar el tipo User
-import { GoogleIcon } from "../icons";
+import { useUser } from '@/contexts/UserContext';
+import { GoogleIcon } from '@/components/icons';
 
 export function AuthButton() {
-  const supabase = createClient(); // Cliente de Supabase en componentes cliente
-  const router = useRouter();
-  const [user, setUser] = useState<User | null>(null);
+  const { user, loading, error, signIn, signOut } = useUser();
 
-  useEffect(() => {
-    const getSession = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      setUser(session?.user || null);
-    };
-
-    getSession();
-  }, [supabase]);
-
-  const handleSignIn = async () => {
-    await supabase.auth.signInWithOAuth({
-      provider: "google",
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`, // URL de redirección dinámica
-      },
-    });
-  };
-
-  const handleSignOut = async () => {
-    await supabase.auth.signOut(); // Cierra sesión en Supabase
-    router.push("/login"); // Redirige a /login
-    router.refresh(); // Refresca la página actual
-  };
+  if (loading) return <p>Cargando...</p>;
+  if (error) return <p>Error: {error}</p>;
 
   return (
     <header>
       {user === null ? (
         <button
-          onClick={handleSignIn}
+          onClick={signIn}
           type="button"
           className="w-60 text-black bg-[#ececec] hover:bg-[#e6e6e6] focus:ring-4 focus:outline-none focus:ring-[#4285F4]/50 font-bold rounded-full text-md py-2 inline-flex items-center justify-start"
         >
@@ -50,11 +22,11 @@ export function AuthButton() {
         </button>
       ) : (
         <button
-          onClick={handleSignOut}
+          onClick={signOut}
           type="button"
-          className="text-white bg-red-500 hover:bg-red-500 focus:outline-none focus:ring-4 focus:ring-red-300 font-medium rounded-full text-sm px-5 py-2.5 text-center mb-0.5 dark:focus:ring-red-900"
+          className="text-white bg-gradient-to-r from-red-400 via-red-500 to-red-600 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-red-300 dark:focus:ring-red-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2"
         >
-          Cerrar sesión
+          Cerrar Sesión
         </button>
       )}
     </header>

--- a/src/components/buttons/sync-button.tsx
+++ b/src/components/buttons/sync-button.tsx
@@ -1,17 +1,18 @@
+import { useSyncModal } from "@/contexts/SyncModalContext";
+import { useUser } from "@/contexts/UserContext";
 import React from "react";
 
 interface SyncButtonProps {
-  showSyncModal: boolean;
-  setSyncModal: (value: boolean) => void;
 }
 
-const SyncButton: React.FC<SyncButtonProps> = ({
-  showSyncModal,
-  setSyncModal,
-}) => {
+const SyncButton: React.FC<SyncButtonProps> = () => {
+    const { openSyncModal } = useSyncModal();
+    const { activeProfile } = useUser();
+
+  if (activeProfile && activeProfile.role_id!==0) return null; //no mostrar el boton si el perfil activo es miembro
   return (
     <button
-      onClick={() => setSyncModal(!showSyncModal)}
+      onClick={() => openSyncModal()}
       type="button"
       className="text-white bg-yellow-400 hover:bg-yellow-500 focus:outline-none focus:ring-4 focus:ring-yellow-300 font-medium rounded-full text-sm px-5 py-2.5 text-center mb-0.5 dark:focus:ring-yellow-900"
     >

--- a/src/components/clubs-table/clubs-table-client.tsx
+++ b/src/components/clubs-table/clubs-table-client.tsx
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import ConfirmationModal from "@/components/modals/confirmation-modal";
 import ErrorModal from "@/components/modals/error-modal";
 import SuccessModal from "@/components/modals/success-modal";
+import { useUser } from "@/contexts/UserContext";
 
 interface Props {
   clubs: Club[];
@@ -18,6 +19,7 @@ export default function ClubTableClient({ clubs }: Props) {
   const [confirmationModal, setconfirmationModal] = useState(false);
   const [errorModal, setErrorModal] = useState<React.ReactNode>(null);
   const [successModal, setSuccessModal] = useState<React.ReactNode>(null);
+  const { refreshProfile } = useUser();
 
   useEffect(() => {
     setFilteredClubs(
@@ -44,6 +46,7 @@ export default function ClubTableClient({ clubs }: Props) {
     if (selectedClub) {
       const [message, success] = await updateUserClub(selectedClub.id);
       if (success) {
+        await refreshProfile();
         setSuccessModal(`${message}`);
       } else {
         setErrorModal(`${message}`);

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -10,26 +10,11 @@ import { redirect } from "next/navigation";
 import { HamburgerIcon, CloseIcon } from "../icons";  // Asegúrate de tener un CloseIcon
 
 interface Props {
-  defaultPopSyncModal: boolean;
-  onCloseSyncModal?: string;
 }
 
-export const Header = ({ defaultPopSyncModal, onCloseSyncModal }: Props) => {
-  const {
-    showSyncModal,
-    openSyncModal,
-    closeSyncModal,
-    popSyncModal,
-    setPopSyncModal,
-  } = useSyncModal();
+export const Header = () => {
 
   const [menuOpen, setMenuOpen] = useState(false);
-
-  useEffect(() => {
-    if (popSyncModal) {
-      openSyncModal();
-    }
-  }, [popSyncModal, openSyncModal]);
 
   return (
     <>
@@ -61,24 +46,14 @@ export const Header = ({ defaultPopSyncModal, onCloseSyncModal }: Props) => {
                 menuOpen ? "block" : "hidden"
               } lg:flex space-x-2 py-6 items-center`}
             >
-              <SyncButton showSyncModal={showSyncModal} setSyncModal={setPopSyncModal} />
+              <SyncButton />
               <AuthButton />
             </div>
           </div>
         </div>
       </header>
 
-      <SyncProfileModal
-        isOpenedByDefault={popSyncModal}
-        isOpen={showSyncModal}
-        onClose={() => {
-          closeSyncModal();
-          if (onCloseSyncModal) {
-            setPopSyncModal(false);
-            redirect(onCloseSyncModal);
-          }
-        }}
-      />
+      <SyncProfileModal/>
     </>
   );
 };

--- a/src/components/syncprofile-modal/actions.ts
+++ b/src/components/syncprofile-modal/actions.ts
@@ -14,7 +14,7 @@ export async function SyncPersonToUser(): Promise<{ success: boolean, error?: st
         }
 
         // Llamar al procedimiento almacenado para sincronización
-        const { data, error } = await supabaseAdmin.rpc('sync_person_to_user', {
+        const { error } = await supabaseAdmin.rpc('sync_person_to_user', {
             user_id: user.user.id,
             user_email: user.user.email || ''
         });
@@ -23,42 +23,10 @@ export async function SyncPersonToUser(): Promise<{ success: boolean, error?: st
             console.error("Error en la sincronización:", error.message);
             return { success: false, error: error.message };
         }
-
-        console.log("DATA:", data);
         return { success: true };
         
     } catch (error) {
         console.error("Error en el proceso de sincronización:", error);
         return { success: false, error: "Error inesperado durante la sincronización" };
     }
-}
-
-export const handleModal = async (openedByDefault: boolean): Promise<Member | null> => {
-        'use server';
-        const supabase = await createClient();
-    
-        const { data: { user }, error } = await supabase.auth.getUser();
-        if (error || !user) {
-          console.error("Error obteniendo usuario o usuario inexistente:", error?.message);
-          return null; // No muestra nada si no hay usuario
-        }
-      
-        const { data: member, error: memberError } = await supabaseAdmin.from("members").select().eq("email", user.email!).single();
-        if (memberError) {
-          console.error("Error al obtener miembro:", memberError.message);
-          return null; // No muestra nada si hay error al obtener el miembro
-        }
-        if(!member || member.auth_user_uuid === user.id) return null; // Si el usuario no tiene perfil miembro, no se muestra el modal
-      
-        // abrir sin importar si ya tiene club
-        if(openedByDefault) return member;
-      
-        // verificar si el invitado ya tiene club
-        const {data: guest, error: guestError} = await supabase.from("guests").select().eq("auth_user_uuid", user.id).single();
-        if(guestError) {
-          console.error("Error al obtener invitado:", guestError.message);
-          return null; // No muestra nada si hay error al obtener el invitado
-        }
-        if(guest.club_id!==0) return null; // Si el invitado ya tiene club, no se muestra el modal
-        return member;
 }

--- a/src/contexts/SyncModalContext.tsx
+++ b/src/contexts/SyncModalContext.tsx
@@ -1,26 +1,42 @@
 'use client'
 
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useState, useCallback } from "react";
+import { useUser } from "./UserContext";
+import { useRouter } from "next/navigation";
 
 interface SyncModalContextType {
     showSyncModal: boolean;
     openSyncModal: () => void;
     closeSyncModal: () => void;
-    popSyncModal: boolean;
-    setPopSyncModal: (value: boolean) => void;
+    syncRedirect: () => void;
 }
 
 const SyncModalContext = createContext<SyncModalContextType | undefined>(undefined);
 
-export const SyncModalProvider = ({ children, defaultPopSyncModal }: { children: React.ReactNode; defaultPopSyncModal: boolean }) => {
+export const SyncModalProvider = ({ children}: { children: React.ReactNode;}) => {
+    const router = useRouter();
+    const { activeProfile, member } = useUser();
     const [showSyncModal, setShowSyncModal] = useState(false);
-    const [popSyncModal, setPopSyncModal] = useState(defaultPopSyncModal);
+    
+    useEffect(() => {
+      const defaultPopSyncModal = !!(activeProfile && activeProfile.club_id === 0 && member);
+      setShowSyncModal(defaultPopSyncModal);
+    
+    }, [activeProfile, member]);
+
+    const syncRedirect = useCallback(() => {
+        console.log("activeProfile en syncRedirect:", activeProfile); // <--- Depuración
+        console.log("club id en syncRedirect:", activeProfile?.club_id); // <--- Depuración
+        if (activeProfile?.club_id === 0) {
+          router.push("/club/select");
+        }
+      }, [activeProfile, router]); // <--- Dependencias
 
     const openSyncModal = () => setShowSyncModal(true);
     const closeSyncModal = () => setShowSyncModal(false);
 
     return (
-        <SyncModalContext.Provider value={{ showSyncModal, openSyncModal, closeSyncModal, popSyncModal, setPopSyncModal }}>
+        <SyncModalContext.Provider value={{ showSyncModal, openSyncModal, closeSyncModal, syncRedirect}}>
             {children}
         </SyncModalContext.Provider>
     );

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createClient } from '@/utils/supabase/client';
+import { User } from '@supabase/supabase-js';
+import { getProfile } from './actions';
+
+interface UserContextType {
+  user: User | null;
+  activeProfile: Member | Guest | null;
+  member: Member | null;
+  loading: boolean;
+  error: string | null;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+  refreshProfile: () => Promise<void>;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider = ({ children }: { children: ReactNode }) => {
+  const supabase = createClient();
+  const [user, setUser] = useState<User | null>(null);
+  const [activeProfile, setActiveProfile] = useState<Member | Guest | null>(null);
+  const [member, setMember] = useState<Member | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const getUser = async () => {
+      const { data: { session }, error } = await supabase.auth.getSession();
+      if (error) {
+        setError(error.message);
+      } else {
+        setUser(session?.user || null);
+      }
+      setLoading(false);
+    };
+    getUser();
+  }, []); // Este efecto se ejecuta solo al montar el componente
+  
+  // Nuevo efecto que reacciona a cambios en el usuario
+  useEffect(() => {
+    if (user) {
+      getProfile(user).then(({ activeProfile, member }) => {
+        setActiveProfile(activeProfile);
+        setMember(member);
+      }).catch((error) => {
+        setError(error.message);
+      });
+    } else {
+      setActiveProfile(null);
+      setMember(null);
+    }
+  }, [user]); // Este efecto se ejecuta cada vez que `user` cambia
+
+  const signIn = async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+    if (error) {
+      setError(error.message);
+    }
+  };
+
+  const signOut = async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      setError(error.message);
+    } else {
+      setUser(null);
+    }
+  };
+
+  const refreshProfile = async () => {
+    if (!user) return;
+    try {
+      const { activeProfile: newProfile, member: newMember } = await getProfile(user);
+      setActiveProfile(newProfile);
+      setMember(newMember);
+    } catch (error) {
+      setError(error as string);
+    }
+  };
+
+  return (
+    <UserContext.Provider value={{ user, activeProfile, member, loading, error, signIn, signOut, refreshProfile }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = () => {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser debe usarse dentro de un UserProvider');
+  }
+  return context;
+};

--- a/src/contexts/actions.ts
+++ b/src/contexts/actions.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import { supabaseAdmin } from '@/utils/supabase/service-role';
+import { createClient } from '@/utils/supabase/server';
+import { User } from '@supabase/supabase-js';
+
+export const getProfile = async (user: User) => {
+    const supabase = await createClient();
+    let activeProfile = null;
+    let member = null;
+
+    if (!user) return { activeProfile: activeProfile, member: member };
+    try {
+        // Buscar en miembros con service role
+        const { data: fetchedMember, error: memberError } = await supabaseAdmin
+          .from('members')
+          .select('*')
+          .eq('email', user.email!)
+          .single();
+    
+        if (!memberError && fetchedMember) {
+            member = fetchedMember;
+            if (fetchedMember.auth_user_uuid === user.id){
+                activeProfile = member;
+                return { activeProfile: activeProfile, member: member };
+            }
+        }
+    
+        // Buscar en invitados
+        const { data: guest, error: guestError } = await supabase
+          .from('guests')
+          .select('*')
+          .eq('auth_user_uuid', user.id)
+          .single();
+    
+        if (!guestError && guest) {
+            activeProfile = guest;
+        }
+    
+        return { activeProfile: activeProfile, member: member };
+    
+      } catch (error) {
+        console.error('Error en getSecureProfile:', error);
+        throw new Error('Error al obtener el perfil');
+      }
+    };


### PR DESCRIPTION
Para entender los cambios, comenzar por el archivo src/app/layout.tsx Se está usando el userContext para manejar el estado del user logueado tanto como del perfil activo, ya sea member o guest. Esto permite que cualquier componente conozca el tipo de usuario y por ejemplo sync-button puede elegir no mostrarse si el perfil activo es miembro.

El userContext tambien se usa dentro del mismo SyncModalProvider para saber si se debe mostrar el modal por default o no. Por eso pude borrar la server action de syncprofile-modal y ahora el mismo Provider se encarga de hacer el fetch y elegir si mostrar el modal o no.

Ahora bien, como los contextos son de react y operan en el cliente, tuve que hacer una server action para poder hacer el fetch en el server y usar el supabaseAdmin para hidratar el userProvider.